### PR TITLE
Instantiate DAOs on demand

### DIFF
--- a/dropwizard-jdbi3-transactions-core/pom.xml
+++ b/dropwizard-jdbi3-transactions-core/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-core/pom.xml
+++ b/dropwizard-jdbi3-transactions-core/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
+    <version>2.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-core/pom.xml
+++ b/dropwizard-jdbi3-transactions-core/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-    <version>2.0</version>
+    <version>2.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.campspot</groupId>
             <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-            <version>1.0</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-test</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.1</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.campspot</groupId>
             <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-            <version>2.0-SNAPSHOT</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-test</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -10,6 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-test</artifactId>
+    <version>1.1-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
* Released 2.0 of core since this is a breaking change (DAOManager constructor signature)
* Released 1.1 of test since it was a non-breaking dependency-only change
