### PR TITLE
Support multiple db connections in DAOManager

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -3,6 +3,8 @@
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/src/main/kotlin" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="libs-release" />
+      <option name="url" value="https://campspot.jfrog.io/campspot/libs-release" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="snapshots" />
+      <option name="name" value="libs-snapshot" />
+      <option name="url" value="https://campspot.jfrog.io/campspot/libs-snapshot" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="ALL" />
+  </component>
   <component name="ChangeListManager">
     <list default="true" id="4720232e-f810-4fec-9e1c-6c766ae3ffbe" name="Default" comment="">
-      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/pom.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/jarRepositories.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/encodings.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/encodings.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/dropwizard-jdbi3-transactions-core.iml" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/dropwizard-jdbi3-transactions-core.iml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/dropwizard-jdbi3-transactions-test.iml" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/dropwizard-jdbi3-transactions-test.iml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/dropwizard-jdbi3-transactions.iml" beforeDir="false" afterPath="$PROJECT_DIR$/dropwizard-jdbi3-transactions.iml" afterDir="false" />
     </list>
-    <ignored path="$PROJECT_DIR$/out/" />
-    <ignored path="$PROJECT_DIR$/target/" />
-    <ignored path="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/target/" />
-    <ignored path="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/target/" />
-    <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -22,52 +27,6 @@
   <component name="DefaultGradleProjectSettings">
     <option name="testRunner" value="GRADLE" />
     <option name="delegatedBuild" value="true" />
-  </component>
-  <component name="FileEditorManager">
-    <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/pom.xml">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="580">
-              <caret line="20" column="19" selection-start-line="20" selection-start-column="19" selection-end-line="20" selection-end-column="19" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="783">
-              <caret line="27" column="47" selection-start-line="27" selection-start-column="47" selection-end-line="27" selection-end-column="47" />
-              <folding>
-                <element signature="e#28#116#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/src/main/kotlin/com/campspot/jdbi3/test/TestDAOManager.kt">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="232">
-              <caret line="8" column="39" selection-start-line="8" selection-start-column="39" selection-end-line="8" selection-end-column="40" />
-              <folding>
-                <element signature="e#33#184#0" expanded="true" />
-              </folding>
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/pom.xml">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="406">
-              <caret line="14" column="18" selection-start-line="14" selection-start-column="18" selection-end-line="14" selection-end-column="18" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-    </leaf>
   </component>
   <component name="FileTemplateManagerImpl">
     <option name="RECENT_TEMPLATES">
@@ -84,54 +43,13 @@
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
-  <component name="IdeDocumentHistory">
-    <option name="CHANGED_PATHS">
-      <list>
-        <option value="$PROJECT_DIR$/src/main/kotlin/com/campspot/jdbi3/DAO.kt" />
-        <option value="$PROJECT_DIR$/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt" />
-        <option value="$PROJECT_DIR$/.gitignore" />
-        <option value="$APPLICATION_CONFIG_DIR$/scratches/scratch_1.txt" />
-        <option value="$PROJECT_DIR$/pom.xml" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionAspect.kt" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/src/main/kotlin/com/campspot/jdbi3/test/TestDAOManager.kt" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/pom.xml" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt" />
-        <option value="$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/pom.xml" />
-      </list>
-    </option>
-  </component>
+  <component name="JupyterTrust" id="042212e3-3712-4f51-921f-2bc944e58985" />
   <component name="MavenImportPreferences">
-    <option name="importingSettings">
-      <MavenImportingSettings>
-        <option name="importAutomatically" value="true" />
-      </MavenImportingSettings>
+    <option name="generalSettings">
+      <MavenGeneralSettings>
+        <option name="mavenHome" value="$APPLICATION_HOME_DIR$/plugins/maven/lib/maven3" />
+      </MavenGeneralSettings>
     </option>
-  </component>
-  <component name="MavenProjectNavigator">
-    <treeState>
-      <expand>
-        <path>
-          <item name="" type="16c1761:MavenProjectsStructure$RootNode" />
-          <item name="dropwizard-jdbi3-transactions" type="9519ce18:MavenProjectsStructure$ProjectNode" />
-        </path>
-        <path>
-          <item name="" type="16c1761:MavenProjectsStructure$RootNode" />
-          <item name="dropwizard-jdbi3-transactions" type="9519ce18:MavenProjectsStructure$ProjectNode" />
-          <item name="Lifecycle" type="58874e2:MavenProjectsStructure$LifecycleNode" />
-        </path>
-        <path>
-          <item name="" type="16c1761:MavenProjectsStructure$RootNode" />
-          <item name="dropwizard-jdbi3-transactions-test" type="9519ce18:MavenProjectsStructure$ProjectNode" />
-        </path>
-        <path>
-          <item name="" type="16c1761:MavenProjectsStructure$RootNode" />
-          <item name="dropwizard-jdbi3-transactions-test" type="9519ce18:MavenProjectsStructure$ProjectNode" />
-          <item name="Lifecycle" type="58874e2:MavenProjectsStructure$LifecycleNode" />
-        </path>
-      </expand>
-      <select />
-    </treeState>
   </component>
   <component name="ProjectFrameBounds" extendedState="6">
     <option name="x" value="858" />
@@ -139,99 +57,13 @@
     <option name="width" value="3840" />
     <option name="height" value="2137" />
   </component>
+  <component name="ProjectId" id="1iWVLCh768q4C3sds1WXjVb3h8v" />
   <component name="ProjectLevelVcsManager" settingsEditedManually="true">
     <ConfirmationsSetting value="2" id="Add" />
   </component>
-  <component name="ProjectView">
-    <navigator proportions="" version="1">
-      <autoscrollFromSource ProjectPane="true" />
-      <foldersAlwaysOnTop value="true" />
-    </navigator>
-    <panes>
-      <pane id="PackagesPane" />
-      <pane id="ProjectPane">
-        <subPane>
-          <expand>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-core" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-core" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-core" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-core" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-              <item name="kotlin" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-core" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-              <item name="kotlin" type="462c0819:PsiDirectoryNode" />
-              <item name="jdbi3" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-test" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-test" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-test" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-test" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-              <item name="kotlin" type="462c0819:PsiDirectoryNode" />
-            </path>
-            <path>
-              <item name="dropwizard-jdbi3-transactions" type="b2602c69:ProjectViewProjectNode" />
-              <item name="dropwizard-jdbi3-transactions" type="462c0819:PsiDirectoryNode" />
-              <item name="dropwizard-jdbi3-transactions-test" type="462c0819:PsiDirectoryNode" />
-              <item name="src" type="462c0819:PsiDirectoryNode" />
-              <item name="main" type="462c0819:PsiDirectoryNode" />
-              <item name="kotlin" type="462c0819:PsiDirectoryNode" />
-              <item name="test" type="462c0819:PsiDirectoryNode" />
-            </path>
-          </expand>
-          <select />
-        </subPane>
-      </pane>
-      <pane id="Scope" />
-    </panes>
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
   </component>
   <component name="PropertiesComponent">
     <property name="SHARE_PROJECT_CONFIGURATION_FILES" value="true" />
@@ -255,18 +87,6 @@
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$" />
     </key>
-  </component>
-  <component name="RunDashboard">
-    <option name="ruleStates">
-      <list>
-        <RuleState>
-          <option name="name" value="ConfigurationTypeDashboardGroupingRule" />
-        </RuleState>
-        <RuleState>
-          <option name="name" value="StatusDashboardGroupingRule" />
-        </RuleState>
-      </list>
-    </option>
   </component>
   <component name="RunManager">
     <configuration default="true" type="Applet">
@@ -307,6 +127,7 @@
       </method>
     </configuration>
   </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
   <component name="SvnConfiguration">
     <configuration />
   </component>
@@ -321,154 +142,12 @@
       <workItem from="1526565455873" duration="2278000" />
       <workItem from="1559955644133" duration="1260000" />
       <workItem from="1561136944279" duration="2325000" />
+      <workItem from="1602023277848" duration="1173000" />
     </task>
     <servers />
   </component>
-  <component name="TimeTrackingManager">
-    <option name="totallyTimeSpent" value="9531000" />
-  </component>
-  <component name="ToolWindowManager">
-    <frame x="858" y="-2137" width="3840" height="2137" extended-state="6" />
-    <layout>
-      <window_info content_ui="combo" id="Project" order="0" visible="true" weight="0.13410771" />
-      <window_info id="Structure" order="1" side_tool="true" weight="0.25" />
-      <window_info id="Designer" order="2" />
-      <window_info id="Image Layers" order="3" />
-      <window_info id="Capture Tool" order="4" />
-      <window_info id="UI Designer" order="5" />
-      <window_info id="Favorites" order="6" side_tool="true" />
-      <window_info anchor="bottom" id="Message" order="0" />
-      <window_info anchor="bottom" id="Find" order="1" />
-      <window_info active="true" anchor="bottom" id="Run" order="2" visible="true" weight="0.3295342" />
-      <window_info anchor="bottom" id="Debug" order="3" weight="0.4" />
-      <window_info anchor="bottom" id="Cvs" order="4" weight="0.25" />
-      <window_info anchor="bottom" id="Inspection" order="5" weight="0.4" />
-      <window_info anchor="bottom" id="TODO" order="6" />
-      <window_info anchor="bottom" id="Terminal" order="7" weight="0.32843652" />
-      <window_info anchor="bottom" id="Docker" order="8" show_stripe_button="false" />
-      <window_info anchor="bottom" id="Event Log" order="9" side_tool="true" />
-      <window_info anchor="bottom" id="Java Enterprise" order="10" />
-      <window_info anchor="bottom" id="Version Control" order="11" />
-      <window_info anchor="bottom" id="Reviews" order="12" />
-      <window_info anchor="bottom" id="Database Changes" order="13" show_stripe_button="false" />
-      <window_info anchor="right" id="Commander" order="0" weight="0.4" />
-      <window_info anchor="right" id="Ant Build" order="1" weight="0.25" />
-      <window_info anchor="right" content_ui="combo" id="Hierarchy" order="2" weight="0.25" />
-      <window_info anchor="right" id="Palette" order="3" />
-      <window_info anchor="right" id="Capture Analysis" order="4" />
-      <window_info anchor="right" id="Key Promoter X" order="5" />
-      <window_info anchor="right" id="Theme Preview" order="6" />
-      <window_info anchor="right" id="Maven Projects" order="7" weight="0.32977587" />
-      <window_info anchor="right" id="News Feed" order="8" />
-      <window_info anchor="right" id="SciView" order="9" />
-      <window_info anchor="right" id="Database" order="10" />
-      <window_info anchor="right" id="Palette&#9;" order="11" />
-      <window_info anchor="right" id="Bean Validation" order="12" />
-      <window_info anchor="right" id="Maven" order="13" visible="true" weight="0.32998943" />
-    </layout>
-  </component>
   <component name="TypeScriptGeneratedFilesManager">
-    <option name="version" value="1" />
-  </component>
-  <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAO.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="99">
-          <caret line="3" column="12" selection-start-line="3" selection-start-column="12" selection-end-line="3" selection-end-column="12" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/.gitignore">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="33">
-          <caret line="1" column="15" selection-start-line="1" selection-start-column="15" selection-end-line="1" selection-end-column="15" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$APPLICATION_CONFIG_DIR$/scratches/scratch_1.txt" />
-    <entry file="file://$PROJECT_DIR$/.editorconfig">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="273">
-          <caret line="13" lean-forward="true" selection-start-line="13" selection-end-line="13" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/InTransaction.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="84">
-          <caret line="4" column="17" selection-start-line="4" selection-start-column="17" selection-end-line="4" selection-end-column="17" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="jar://$MAVEN_REPOSITORY$/org/jdbi/jdbi3-core/3.0.1/jdbi3-core-3.0.1-sources.jar!/org/jdbi/v3/core/transaction/DelegatingTransactionHandler.java" />
-    <entry file="jar://$MAVEN_REPOSITORY$/org/jdbi/jdbi3-core/3.0.1/jdbi3-core-3.0.1-sources.jar!/org/jdbi/v3/core/transaction/TransactionHandler.java" />
-    <entry file="jar://$MAVEN_REPOSITORY$/org/jdbi/jdbi3-core/3.0.1/jdbi3-core-3.0.1-sources.jar!/org/jdbi/v3/core/Handle.java" />
-    <entry file="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/1.2.21/kotlin-stdlib-1.2.21-sources.jar!/kotlin/Any.kt" />
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="486">
-          <caret line="37" column="31" selection-start-line="37" selection-start-column="31" selection-end-line="37" selection-end-column="31" />
-          <folding>
-            <element signature="e#28#517#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionAspect.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="807">
-          <caret line="49" column="2" selection-start-line="49" selection-start-column="2" selection-end-line="49" selection-end-column="2" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="jar://$MAVEN_REPOSITORY$/com/campspot/dropwizard-jdbi3-transactions-core/2.2/dropwizard-jdbi3-transactions-core-2.2.jar!/com/campspot/jdbi3/DAOManager.class">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="145">
-          <caret line="5" column="36" selection-start-line="5" selection-start-column="36" selection-end-line="5" selection-end-column="36" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/src/main/kotlin/com/campspot/jdbi3/test/TestDAOManager.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="232">
-          <caret line="8" column="39" selection-start-line="8" selection-start-column="39" selection-end-line="8" selection-end-column="40" />
-          <folding>
-            <element signature="e#33#184#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/pom.xml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="261">
-          <caret line="9" column="1" selection-start-line="9" selection-start-column="1" selection-end-line="9" selection-end-column="26" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/pom.xml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="580">
-          <caret line="20" column="19" selection-start-line="20" selection-start-column="19" selection-end-line="20" selection-end-column="19" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/DAOManager.kt">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="783">
-          <caret line="27" column="47" selection-start-line="27" selection-start-column="47" selection-end-line="27" selection-end-column="47" />
-          <folding>
-            <element signature="e#28#116#0" expanded="true" />
-          </folding>
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/dropwizard-jdbi3-transactions-test/pom.xml">
-      <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="406">
-          <caret line="14" column="18" selection-start-line="14" selection-start-column="18" selection-end-line="14" selection-end-column="18" />
-        </state>
-      </provider>
-    </entry>
+    <option name="version" value="3" />
   </component>
   <component name="masterDetails">
     <states>

--- a/dropwizard-jdbi3-transactions-core/dropwizard-jdbi3-transactions-core.iml
+++ b/dropwizard-jdbi3-transactions-core/dropwizard-jdbi3-transactions-core.iml
@@ -6,15 +6,14 @@
         <compilerSettings />
         <compilerArguments>
           <option name="jvmTarget" value="1.8" />
-          <option name="languageVersion" value="1.2" />
-          <option name="apiVersion" value="1.2" />
+          <option name="languageVersion" value="1.3" />
+          <option name="apiVersion" value="1.3" />
           <option name="pluginOptions">
             <array />
           </option>
           <option name="pluginClasspaths">
             <array />
           </option>
-          <option name="coroutinesState" value="warn" />
           <option name="errors">
             <ArgumentParseErrors />
           </option>
@@ -35,6 +34,19 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" name="Maven: net.jodah:expiringmap:0.5.6" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.21" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-server:2.25.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-common:2.25.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.bundles.repackaged:jersey-guava:2.25.1" level="project" />
@@ -50,20 +62,22 @@
     <orderEntry type="library" name="Maven: org.glassfish.hk2:hk2-locator:2.5.0-b32" level="project" />
     <orderEntry type="library" name="Maven: org.javassist:javassist:3.20.0-GA" level="project" />
     <orderEntry type="library" name="Maven: javax.validation:validation-api:1.1.0.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
-    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr4-runtime:4.7.2" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Maven: net.jodah:expiringmap:0.5.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: io.leangen.geantyref:geantyref:1.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ben-manes.caffeine:caffeine:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.checkerframework:checker-qual:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.13.0" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.0.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.3.61" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.3.70" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test-common:1.3.70" level="project" />
   </component>
 </module>

--- a/dropwizard-jdbi3-transactions-core/pom.xml
+++ b/dropwizard-jdbi3-transactions-core/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>dropwizard-jdbi3-transactions</artifactId>
         <groupId>com.campspot</groupId>
-        <version>1.1</version>
+        <version>1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-    <version>2.7</version>
+    <version>2.8</version>
 
     <dependencies>
         <dependency>

--- a/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt
+++ b/dropwizard-jdbi3-transactions-core/src/main/kotlin/com/campspot/jdbi3/TransactionEventListener.kt
@@ -20,7 +20,7 @@ class TransactionApplicationListener(private val daoManager: DAOManager) : Appli
     dbis[name] = jdbi
   }
 
-  private class TransactionEventListener internal constructor(
+  private class TransactionEventListener(
     private val methodMap: ConcurrentMap<ResourceMethod, InTransaction?>,
     daoManager: DAOManager,
     dbis: Map<String, Jdbi>

--- a/dropwizard-jdbi3-transactions-test/dropwizard-jdbi3-transactions-test.iml
+++ b/dropwizard-jdbi3-transactions-test/dropwizard-jdbi3-transactions-test.iml
@@ -6,15 +6,14 @@
         <compilerSettings />
         <compilerArguments>
           <option name="jvmTarget" value="1.8" />
-          <option name="languageVersion" value="1.2" />
-          <option name="apiVersion" value="1.2" />
+          <option name="languageVersion" value="1.3" />
+          <option name="apiVersion" value="1.3" />
           <option name="pluginOptions">
             <array />
           </option>
           <option name="pluginClasspaths">
             <array />
           </option>
-          <option name="coroutinesState" value="warn" />
           <option name="errors">
             <ArgumentParseErrors />
           </option>
@@ -34,6 +33,19 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: com.campspot:dropwizard-jdbi3-transactions-core:2.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" name="Maven: net.jodah:expiringmap:0.5.6" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.0.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.21" level="project" />
     <orderEntry type="module" module-name="dropwizard-jdbi3-transactions-core" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-server:2.25.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish.jersey.core:jersey-common:2.25.1" level="project" />
@@ -54,20 +66,22 @@
     <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy:1.7.9" level="project" />
     <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy-agent:1.7.9" level="project" />
     <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.21" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
-    <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
-    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr4-runtime:4.7.2" level="project" />
     <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
-    <orderEntry type="library" name="Maven: net.jodah:expiringmap:0.5.6" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.0.1" level="project" />
+    <orderEntry type="library" name="Maven: io.leangen.geantyref:geantyref:1.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ben-manes.caffeine:caffeine:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.checkerframework:checker-qual:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.13.0" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.0" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.0.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.3.61" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.3.70" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test-common:1.3.70" level="project" />
   </component>
 </module>

--- a/dropwizard-jdbi3-transactions-test/pom.xml
+++ b/dropwizard-jdbi3-transactions-test/pom.xml
@@ -5,18 +5,18 @@
     <parent>
         <artifactId>dropwizard-jdbi3-transactions</artifactId>
         <groupId>com.campspot</groupId>
-        <version>1.1</version>
+        <version>1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>dropwizard-jdbi3-transactions-test</artifactId>
-    <version>2.7</version>
+    <version>2.8</version>
 
     <dependencies>
         <dependency>
             <groupId>com.campspot</groupId>
             <artifactId>dropwizard-jdbi3-transactions-core</artifactId>
-            <version>2.7</version>
+            <version>2.8</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/dropwizard-jdbi3-transactions.iml
+++ b/dropwizard-jdbi3-transactions.iml
@@ -6,15 +6,14 @@
         <compilerSettings />
         <compilerArguments>
           <option name="jvmTarget" value="1.8" />
-          <option name="languageVersion" value="1.2" />
-          <option name="apiVersion" value="1.2" />
+          <option name="languageVersion" value="1.3" />
+          <option name="apiVersion" value="1.3" />
           <option name="pluginOptions">
             <array />
           </option>
           <option name="pluginClasspaths">
             <array />
           </option>
-          <option name="coroutinesState" value="warn" />
           <option name="errors">
             <ArgumentParseErrors />
           </option>
@@ -40,13 +39,28 @@
     <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
     <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Maven: net.jodah:expiringmap:0.5.6" level="project" />
     <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.0.1" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.0.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.2.21" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.70" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-core:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr4-runtime:4.7.2" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
+    <orderEntry type="library" name="Maven: io.leangen.geantyref:geantyref:1.3.7" level="project" />
+    <orderEntry type="library" name="Maven: com.github.ben-manes.caffeine:caffeine:2.8.0" level="project" />
+    <orderEntry type="library" name="Maven: org.checkerframework:checker-qual:2.10.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.3.61" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-kotlin-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jdbi:jdbi3-sqlobject:3.13.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.3.70" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test-common:1.3.70" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.campspot</groupId>
     <artifactId>dropwizard-jdbi3-transactions</artifactId>
     <packaging>pom</packaging>
-    <version>1.1</version>
+    <version>1.2</version>
     <modules>
         <module>dropwizard-jdbi3-transactions-core</module>
         <module>dropwizard-jdbi3-transactions-test</module>


### PR DESCRIPTION
We already supported connections to multiple different dbs in the annotation and event handler, but it was confusing to set up because we only allow one of the connections into the DAOManager. This fixes that